### PR TITLE
Fix cut-release action to use repo's binaries

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -28,5 +28,8 @@ jobs:
       metadataAuthors: "Kraken"
       metadataTags: "challenge,gameplay-mod"
       metadataWebsiteUrl: "https://github.com/RealOfficialKraken/OG-HeroMode-Plus"
+      skipMacOS: true
+      skipLinux: true
+      toolingBinaryDir: "out/build/Release/bin"
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Without this it's trying to use the most recent vanilla jak-project release, which has incompatible binaries with your codebase at the moment